### PR TITLE
Fixing Extra Drawn Row

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ impl<'a> ImageRoi<'a> {
     pub fn draw(&self, window: &mut Window, x: i32, mut y: i32) {
         let stride = self.image.w;
         let mut offset = (self.y * stride + self.x) as usize;
-        let end = cmp::min(((self.y + self.h) * stride + self.x + self.w) as usize, self.image.data.len());
+        let end = cmp::min(((self.y + self.h - 1) * stride + self.x + self.w) as usize, self.image.data.len());
         while offset < end {
             let next_offset = offset + stride as usize;
             window.image(x, y, self.w, 1, &self.image.data[offset..]);


### PR DESCRIPTION
The ImageRoi was drawing an extra row due to how it calculated the endpoint for its row-by-row approach. Fix involved a reduction by 1 of the rows considered.

Of note, ImageRois with no height and a width smaller than the total images width could result in a negative `end`, which in turn would cause nothing to be drawn; this isn't strictly an issue though, as no height implies nothing drawn.
